### PR TITLE
Support local images

### DIFF
--- a/src/Core.Tests/LocalImageTest.cs
+++ b/src/Core.Tests/LocalImageTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Docker.DotNet;
+using Docker.DotNet.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace Squadron
+{
+    public class LocalImageTest : IClassFixture<GenericContainerResource<LocalAppOptions>>
+    {
+        public static string LocalTagName { get; } = "test-image";
+        public static string LocalTagVersion { get; } = "1.0.0";
+
+        public static DockerClient DockerClient =
+            new DockerClientConfiguration(
+                LocalDockerUri(),
+                null,
+                TimeSpan.FromMinutes(5))
+            .CreateClient();
+
+        private GenericContainerResource<LocalAppOptions> _containerResource;
+
+        public LocalImageTest(GenericContainerResource<LocalAppOptions> containerResource)
+        {
+            _containerResource = containerResource;
+        }
+
+        [Fact]
+        public async Task UseLocalImageTest()
+        {
+            Uri containerUri = _containerResource.GetContainerUri();
+            containerUri.Should().NotBeNull();
+
+            await DockerClient.Images.DeleteImageAsync(
+                $"{LocalTagName}:{LocalTagVersion}",
+                new ImageDeleteParameters(),
+                CancellationToken.None);
+        }
+
+        private static Uri LocalDockerUri()
+        {
+            #if NET461
+            return new Uri("npipe://./pipe/docker_engine");
+            #else
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return isWindows ?
+                new Uri("npipe://./pipe/docker_engine") :
+                new Uri("unix:/var/run/docker.sock");
+            #endif
+        }
+    }
+
+    public class LocalAppOptions : GenericContainerOptions
+    {
+        public async Task CreateAndTagImage()
+        {
+            void Handler(JSONMessage message)
+            {
+                if (!string.IsNullOrEmpty(message.ErrorMessage))
+                {
+                    throw new ContainerException(
+                        $"Error: {message.ErrorMessage}");
+                }
+            }
+
+            // Pulling Nginx image
+            await LocalImageTest.DockerClient.Images.CreateImageAsync(
+                new ImagesCreateParameters
+                {
+                    FromImage = "nginx:latest",
+                },
+                null,
+                new Progress<JSONMessage>(Handler),
+                CancellationToken.None);
+
+            // Re-tagging the Nginx image to our test name
+            await LocalImageTest.DockerClient.Images.TagImageAsync(
+                "nginx:latest",
+                new ImageTagParameters
+                {
+                    Tag = LocalImageTest.LocalTagVersion,
+                    RepositoryName = LocalImageTest.LocalTagName
+                },
+                CancellationToken.None);
+        }
+
+        public override void Configure(ContainerResourceBuilder builder)
+        {
+            CreateAndTagImage().Wait();
+
+            base.Configure(builder);
+            builder
+                .Name("local-demo-image")
+                .InternalPort(80)
+                .Image(LocalImageTest.LocalTagName)
+                .Tag(LocalImageTest.LocalTagVersion)
+                .PreferLocalImage(true);
+        }
+    }
+}

--- a/src/Core.Tests/LocalImageTests.cs
+++ b/src/Core.Tests/LocalImageTests.cs
@@ -23,7 +23,7 @@ namespace Squadron
 
         private GenericContainerResource<LocalAppOptions> _containerResource;
 
-        public LocalImageTest(GenericContainerResource<LocalAppOptions> containerResource)
+        public LocalImageTests(GenericContainerResource<LocalAppOptions> containerResource)
         {
             _containerResource = containerResource;
         }

--- a/src/Core.Tests/LocalImageTests.cs
+++ b/src/Core.Tests/LocalImageTests.cs
@@ -67,7 +67,7 @@ namespace Squadron
             }
 
             // Pulling Nginx image
-            await LocalImageTest.DockerClient.Images.CreateImageAsync(
+            await LocalImageTests.DockerClient.Images.CreateImageAsync(
                 new ImagesCreateParameters
                 {
                     FromImage = "nginx:latest",
@@ -77,12 +77,12 @@ namespace Squadron
                 CancellationToken.None);
 
             // Re-tagging the Nginx image to our test name
-            await LocalImageTest.DockerClient.Images.TagImageAsync(
+            await LocalImageTests.DockerClient.Images.TagImageAsync(
                 "nginx:latest",
                 new ImageTagParameters
                 {
-                    Tag = LocalImageTest.LocalTagVersion,
-                    RepositoryName = LocalImageTest.LocalTagName
+                    Tag = LocalImageTests.LocalTagVersion,
+                    RepositoryName = LocalImageTests.LocalTagName
                 },
                 CancellationToken.None);
         }
@@ -95,8 +95,8 @@ namespace Squadron
             builder
                 .Name("local-demo-image")
                 .InternalPort(80)
-                .Image(LocalImageTest.LocalTagName)
-                .Tag(LocalImageTest.LocalTagVersion)
+                .Image(LocalImageTests.LocalTagName)
+                .Tag(LocalImageTests.LocalTagVersion)
                 .PreferLocalImage();
         }
     }

--- a/src/Core.Tests/LocalImageTests.cs
+++ b/src/Core.Tests/LocalImageTests.cs
@@ -31,7 +31,12 @@ namespace Squadron
         [Fact]
         public async Task UseLocalImageTest()
         {
+            // Arrange: See LocalAppOptions
+
+            // Act
             Uri containerUri = _containerResource.GetContainerUri();
+
+            // Assert
             containerUri.Should().NotBeNull();
 
             await DockerClient.Images.DeleteImageAsync(

--- a/src/Core.Tests/LocalImageTests.cs
+++ b/src/Core.Tests/LocalImageTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Squadron
 {
-    public class LocalImageTest : IClassFixture<GenericContainerResource<LocalAppOptions>>
+    public class LocalImageTests : IClassFixture<GenericContainerResource<LocalAppOptions>>
     {
         public static string LocalTagName { get; } = "test-image";
         public static string LocalTagVersion { get; } = "1.0.0";
@@ -97,7 +97,7 @@ namespace Squadron
                 .InternalPort(80)
                 .Image(LocalImageTest.LocalTagName)
                 .Tag(LocalImageTest.LocalTagVersion)
-                .PreferLocalImage(true);
+                .PreferLocalImage();
         }
     }
 }

--- a/src/Core/ContainerResourceBuilder.cs
+++ b/src/Core/ContainerResourceBuilder.cs
@@ -182,11 +182,10 @@ namespace Squadron
         /// Sets the setting, wheter squadron should pull the image or look for a local image first.
         /// If not set, squadron will always pull the image
         /// </summary>
-        /// <param name="preferLocalImage">The local image preferrence setting</param>
         /// <returns></returns>
-        public ContainerResourceBuilder PreferLocalImage(bool preferLocalImage)
+        public ContainerResourceBuilder PreferLocalImage()
         {
-            _options.PreferLocalImage = preferLocalImage;
+            _options.PreferLocalImage = true;
             return this;
         }
 

--- a/src/Core/ContainerResourceBuilder.cs
+++ b/src/Core/ContainerResourceBuilder.cs
@@ -179,6 +179,18 @@ namespace Squadron
         }
 
         /// <summary>
+        /// Sets the setting, wheter squadron should pull the image or look for a local image first.
+        /// If not set, squadron will always pull the image
+        /// </summary>
+        /// <param name="preferLocalImage">The local image preferrence setting</param>
+        /// <returns></returns>
+        public ContainerResourceBuilder PreferLocalImage(bool preferLocalImage)
+        {
+            _options.PreferLocalImage = preferLocalImage;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the settings
         /// </summary>
         /// <returns></returns>

--- a/src/Core/ContainerResourceSettings.cs
+++ b/src/Core/ContainerResourceSettings.cs
@@ -90,7 +90,7 @@ namespace Squadron
         /// Wheter to alway pull an image or look for a local one
         /// </summary>
         /// <value></value>
-        public bool PreferLocalImage {get; internal set;}
+        public bool PreferLocalImage {get; internal set;} = false;
 
         /// <summary>
         /// Gets the docker configuration resolver.

--- a/src/Core/ContainerResourceSettings.cs
+++ b/src/Core/ContainerResourceSettings.cs
@@ -43,7 +43,7 @@ namespace Squadron
         /// The name of the registry.
         /// </value>
         public string RegistryName { get; internal set; }
-        
+
         public ContainerAddressMode AddressMode { get; internal set; }
 
         /// <summary>
@@ -85,6 +85,12 @@ namespace Squadron
         /// Unique container name
         /// </summary>
         public string UniqueContainerName { get; internal set; }
+
+        /// <summary>
+        /// Wheter to alway pull an image or look for a local one
+        /// </summary>
+        /// <value></value>
+        public bool PreferLocalImage {get; internal set;}
 
         /// <summary>
         /// Gets the docker configuration resolver.

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -100,11 +100,11 @@ namespace Squadron
         /// <inheritdoc/>
         public async Task CreateAndStartContainerAsync()
         {
-            if (!(await ImageExists()))
+            if (!_settings.PreferLocalImage || !await ImageExists())
             {
                 await PullImageAsync();
-
             }
+            
             await CreateContainerAsync();
             await StartContainerAsync();
             await ConnectToNetworksAsync();

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -100,7 +100,11 @@ namespace Squadron
         /// <inheritdoc/>
         public async Task CreateAndStartContainerAsync()
         {
-            await PullImageAsync();
+            if (!(await ImageExists()))
+            {
+                await PullImageAsync();
+
+            }
             await CreateContainerAsync();
             await StartContainerAsync();
             await ConnectToNetworksAsync();
@@ -164,7 +168,7 @@ namespace Squadron
                         }
                     });
             }
-            catch ( Exception ex)
+            catch (Exception ex)
             {
                 throw new ContainerException(
                     $"Error in RemoveContainer: {_settings.UniqueContainerName}", ex);
@@ -328,6 +332,22 @@ namespace Squadron
             }
         }
 
+        public async Task<bool> ImageExists()
+        {
+            try
+            {
+                return await retryPolicy
+                     .ExecuteAsync(async () =>
+                         return (await _client.Images.ListImagesAsync(
+                             new ImagesListParameters { MatchName = _settings.ImageFullname })).Any()
+                     );
+            }
+            catch (Exception ex)
+            {
+                throw new ContainerException(
+                    $"Error in ImageExists: {_settings.ImageFullname }", ex);
+            }
+        }
 
         private async Task PullImageAsync()
         {
@@ -346,13 +366,13 @@ namespace Squadron
                 await retryPolicy
                     .ExecuteAsync(async () =>
                    {
-                        await _client.Images.CreateImageAsync(
-                        new ImagesCreateParameters { FromImage = _settings.ImageFullname },
-                        _authConfig,
-                        new Progress<JSONMessage>(Handler));
-                    });
+                       await _client.Images.CreateImageAsync(
+                       new ImagesCreateParameters { FromImage = _settings.ImageFullname },
+                       _authConfig,
+                       new Progress<JSONMessage>(Handler));
+                   });
             }
-            catch ( Exception ex)
+            catch (Exception ex)
             {
                 throw new ContainerException(
                     $"Error in PullImage: {_settings.ImageFullname }", ex);
@@ -476,7 +496,7 @@ namespace Squadron
             }
             return result.ToString();
         }
-        
+
         private async Task ConnectToNetworksAsync()
         {
             foreach (string networkName in _settings.Networks)

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -338,8 +338,13 @@ namespace Squadron
             {
                 return await retryPolicy
                      .ExecuteAsync(async () =>
-                         return (await _client.Images.ListImagesAsync(
-                             new ImagesListParameters { MatchName = _settings.ImageFullname })).Any()
+                         {
+                             IEnumerable<ImagesListResponse> listResponse =
+                             await _client.Images.ListImagesAsync(
+                                 new ImagesListParameters { MatchName = _settings.ImageFullname });
+
+                             return listResponse.Any();
+                         }
                      );
             }
             catch (Exception ex)


### PR DESCRIPTION
You have now the option to use local images for your squadron containers.
Usage:

builder.PreferLocalImage(); --> Local image will be used if available, if not, it will be pulled from the defined registry as normal.
This option is set to false by default.
