### PR TITLE
Fix azure blob storage

### DIFF
--- a/src/AzureStorage/CloudStorageAccountBuilder.cs
+++ b/src/AzureStorage/CloudStorageAccountBuilder.cs
@@ -20,7 +20,7 @@ namespace Squadron
             return 
                 $"DefaultEndpointsProtocol=http;AccountName={dev.Credentials.AccountName};" +
                 $"AccountKey={dev.Credentials.ExportBase64EncodedKey()};" +
-                $"{endpoint}=http://{instance.Address}:{instance.HostPort}/" +
+                $"{endpoint}=http://{instance.IpAddress}:{instance.HostPort}/" +
                 $"{dev.Credentials.AccountName};";
         }
 


### PR DESCRIPTION
The Azure Blob Storage SDK cannot deal with URLs in the format of `localhost:12345`. it has to be `127.0.0.1:12345`
 