### PR TITLE
Handle non root user for MS SqlServer 2017/2019

### DIFF
--- a/src/Core/ChmodCommand.cs
+++ b/src/Core/ChmodCommand.cs
@@ -1,0 +1,65 @@
+
+using System;
+using Docker.DotNet.Models;
+
+namespace Squadron
+{
+    /// <summary>
+    /// Execute a chmod command as root
+    /// </summary>
+    public static class ChmodCommand
+    {
+        /// <summary>
+        /// Change file mode
+        /// </summary>
+        /// <param name="pathInContainer">Path within container</param>
+        /// <param name="owner"><see cref="Permission"/> for owner</param>
+        /// <param name="group"><see cref="Permission"/> for group</param>
+        /// <param name="public"><see cref="Permission"/> for public</param>
+        /// <param name="recursive">Apply recursive</param>
+        public static ContainerExecCreateParameters Set(
+            string pathInContainer,
+            Permission owner = Permission.None,
+            Permission group = Permission.None,
+            Permission @public = Permission.None,
+            bool recursive = false)
+        {
+            var cmd = $"chmod {(recursive ? "-R " : "")}{owner:d}{group:d}{@public:d} {pathInContainer}";
+
+            return new ContainerExecCreateParameters
+            {
+                AttachStderr = true,
+                AttachStdin = false,
+                AttachStdout = true,
+                Cmd = cmd.Split(' '),
+                Detach = false,
+                Tty = false,
+                Privileged = true,
+                User = "root"
+            };
+        }
+
+        public static ContainerExecCreateParameters ReadOnly(string pathInContainer, bool recursive = false)
+            => Set(pathInContainer, Permission.Read, Permission.Read, Permission.Read, recursive);
+
+        public static ContainerExecCreateParameters FullAccess(string pathInContainer, bool recursive = false)
+            => Set(pathInContainer, Permission.FullAccess, Permission.FullAccess, Permission.FullAccess, recursive);
+
+        public static ContainerExecCreateParameters Execute(string pathInContainer, bool recursive = false)
+            => Set(pathInContainer, Permission.Execute, Permission.Execute, Permission.Execute, recursive);
+
+        public static ContainerExecCreateParameters ReadWrite(string pathInContainer, bool recursive = false)
+            => Set(pathInContainer, Permission.ReadWrite, Permission.ReadWrite, Permission.ReadWrite, recursive);
+
+        [Flags]
+        public enum Permission
+        {
+            None = 0b000,
+            Read = 0b100,
+            Write = 0b010,
+            Execute = 0b001,
+            FullAccess = Read | Write | Execute,
+            ReadWrite = Read | Write
+        }
+    }
+}

--- a/src/SqlServer.Tests/Resources/SqlServer2019Options.cs
+++ b/src/SqlServer.Tests/Resources/SqlServer2019Options.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Squadron.Resources
+{
+    /// <summary>
+    /// SqlServer 2019 options
+    /// </summary>
+    public class SqlServer2019Options : ContainerResourceOptions
+    {
+        /// <summary>
+        /// Configure resource options
+        /// </summary>
+        /// <param name="builder"></param>
+        public override void Configure(ContainerResourceBuilder builder)
+        {
+            var password = "_Qtp" + Guid.NewGuid().ToString("N");
+            builder
+                .Name("mssql")
+                .Image("mcr.microsoft.com/mssql/server:2019-latest")
+                .InternalPort(1433)
+                .Username("sa")
+                .Password(password)
+                .AddEnvironmentVariable("ACCEPT_EULA=Y")
+                .AddEnvironmentVariable($"SA_PASSWORD={password}");
+        }
+    }
+}

--- a/src/SqlServer.Tests/SqlServer2019Tests.cs
+++ b/src/SqlServer.Tests/SqlServer2019Tests.cs
@@ -1,0 +1,77 @@
+// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Squadron.Resources;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Squadron
+{
+    public class SqlServer2019Tests
+        : IClassFixture<SqlServerResource<SqlServer2019Options>>
+    {
+        private readonly SqlServerResource<SqlServer2019Options> _resource;
+        private readonly ITestOutputHelper _logger;
+
+        public SqlServer2019Tests(SqlServerResource<SqlServer2019Options> resource, ITestOutputHelper logger)
+        {
+            _resource = resource;
+            _logger = logger;
+        }
+
+        [Fact]
+        public async Task SqlServer2019Resource_Empty_Created()
+        {
+            // arrange
+            const string databaseName = "Sales_DEABB989";
+
+            // act
+            var connectionString = await _resource.CreateDatabaseAsync(databaseName);
+
+            // assert
+            string retrievedDatabaseName = FindDatabase(connectionString, databaseName);
+            Assert.Equal(databaseName, retrievedDatabaseName);
+        }
+
+        private string FindDatabase(string databaseConnection, string databaseName)
+        {
+            string value = null;
+            try
+            {
+                using (var connection = new SqlConnection(databaseConnection))
+                {
+                    connection.Open();
+                    _logger.WriteLine("Connection is open.");
+
+                    using (var command = new SqlCommand($"SELECT * FROM sys.databases WHERE name = '{databaseName}'",
+                        connection))
+                    {
+                        value = (string) command.ExecuteScalar();
+                        _logger.WriteLine("Database name retrieved.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.WriteLine("FindDatabase failed.");
+                _logger.WriteLine(ex.Message);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/SqlServer.Tests/SqlServer2019Tests.cs
+++ b/src/SqlServer.Tests/SqlServer2019Tests.cs
@@ -1,17 +1,3 @@
-// Copyright 2020 Energinet DataHub A/S
-//
-// Licensed under the Apache License, Version 2.0 (the "License2");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 using System;
 using System.Data.SqlClient;
 using System.Threading.Tasks;

--- a/src/SqlServer/SqlServerResource.cs
+++ b/src/SqlServer/SqlServerResource.cs
@@ -102,6 +102,9 @@ namespace Squadron
                 await Manager.CopyToContainerAsync(copyContext);
 
                 await Manager.InvokeCommandAsync(
+                    ChmodCommand.ReadWrite($"/tmp/{scriptFile.Name}"));
+
+                await Manager.InvokeCommandAsync(
                     SqlCommand.ExecuteFile(copyContext.Destination, Settings));
 
                 _databases.Add(databaseName);


### PR DESCRIPTION
With the introduction of SQL Server 2017/2019 the engine is no long run under root.

When the database script was copied to the container this was done as root.
This prevented the `mssql-user` from reading the script file and create a database and execute any seed data.

This PR executes a `chmod 666` on the script file when it has been copied there by the `mssql-user` can read the content and will not fail. 