### PR TITLE
Feature/service bus namespace create if not exists

### DIFF
--- a/src/AzureCloudServiceBus/AzureCloudServiceBusResource.cs
+++ b/src/AzureCloudServiceBus/AzureCloudServiceBusResource.cs
@@ -175,14 +175,13 @@ namespace Squadron
             {
                 _serviceBusModel.ProvisioningMode = ServiceBusProvisioningMode.CreateAndDelete;
                 _serviceBusModel.Namespace = await
-                    _serviceBusManager.CreateNamespaceAsync(AzureConfig.DefaultLocation);
+                    _serviceBusManager.CreateRandomNamespaceAsync(AzureConfig.DefaultLocation);
             }
-            else if (_serviceBusModel.ProvisioningMode == ServiceBusProvisioningMode.CreateOrUpdate)
+            else if (_serviceBusModel.ProvisioningMode == ServiceBusProvisioningMode.CreateIfNotExists)
             {
                 _serviceBusModel.Namespace = await
-                    _serviceBusManager.CreateNamespaceAsync(AzureConfig.DefaultLocation, _serviceBusModel.Namespace);
+                    _serviceBusManager.CreateNamespaceIfNotExistsAsync(AzureConfig.DefaultLocation, _serviceBusModel.Namespace);
             }
-
         }
 
         private async Task PrepareQueuesAsync()

--- a/src/AzureCloudServiceBus/AzureCloudServiceBusResource.cs
+++ b/src/AzureCloudServiceBus/AzureCloudServiceBusResource.cs
@@ -13,7 +13,7 @@ using Xunit.Sdk;
 namespace Squadron
 {
     /// <summary>
-    /// Defines a Azure Cloud ServiceBus namespace 
+    /// Defines a Azure Cloud ServiceBus namespace
     /// </summary>
     /// <typeparam name="TOptions">Option to initialize the resource</typeparam>
     public class AzureCloudServiceBusResource<TOptions>
@@ -177,6 +177,12 @@ namespace Squadron
                 _serviceBusModel.Namespace = await
                     _serviceBusManager.CreateNamespaceAsync(AzureConfig.DefaultLocation);
             }
+            else if (_serviceBusModel.ProvisioningMode == ServiceBusProvisioningMode.CreateOrUpdate)
+            {
+                _serviceBusModel.Namespace = await
+                    _serviceBusManager.CreateNamespaceAsync(AzureConfig.DefaultLocation, _serviceBusModel.Namespace);
+            }
+
         }
 
         private async Task PrepareQueuesAsync()

--- a/src/AzureCloudServiceBus/Model/ServiceBusModel.cs
+++ b/src/AzureCloudServiceBus/Model/ServiceBusModel.cs
@@ -63,6 +63,6 @@ namespace Squadron
         /// <summary>
         /// Create or update resource
         /// </summary>
-        CreateOrUpdate
+        CreateIfNotExists
     }
 }

--- a/src/AzureCloudServiceBus/Model/ServiceBusModel.cs
+++ b/src/AzureCloudServiceBus/Model/ServiceBusModel.cs
@@ -7,7 +7,7 @@ namespace Squadron
     /// <summary>
     /// Azure ServiceBus model
     /// </summary>
-    public class ServiceBusModel 
+    public class ServiceBusModel
     {
         /// <summary>
         /// Gets or sets the namespace.
@@ -58,6 +58,11 @@ namespace Squadron
         /// <summary>
         /// Provision and delete resource
         /// </summary>
-        CreateAndDelete
+        CreateAndDelete,
+
+        /// <summary>
+        /// Create or update resource
+        /// </summary>
+        CreateOrUpdate
     }
 }

--- a/src/AzureCloudServiceBus/ServiceBusManager.cs
+++ b/src/AzureCloudServiceBus/ServiceBusManager.cs
@@ -56,6 +56,23 @@ namespace Squadron
             return res.Name;
         }
 
+        internal async Task<string> CreateNamespaceAsync(string location, string serviceBusNamespace)
+        {
+            await EnsureAuthenticatedAsync();
+
+            var pars = new SBNamespace
+            {
+                Sku = new SBSku(SkuName.Standard),
+                Location = location
+            };
+
+            SBNamespace res = await _client.Namespaces
+                .CreateOrUpdateAsync(_identifier.ResourceGroupName, serviceBusNamespace, pars);
+
+            _identifier.Name = res.Name;
+            return res.Name;
+        }
+
         internal async Task CreateTopic(ServiceBusTopicModel model)
         {
             await EnsureAuthenticatedAsync();

--- a/src/AzureCloudServiceBus/ServiceBusOptionsBuilder.cs
+++ b/src/AzureCloudServiceBus/ServiceBusOptionsBuilder.cs
@@ -30,13 +30,13 @@ namespace Squadron
         /// Namespace
         /// </summary>
         /// <param name="ns">The namespace.</param>
-        /// <param name="createOrUpdate">creates namespace if doesn't exist.</param>
+        /// <param name="createIfNotExists">creates namespace if doesn't exist.</param>
         /// <returns></returns>
-        public ServiceBusOptionsBuilder Namespace(string ns, bool createOrUpdate = false)
+        public ServiceBusOptionsBuilder Namespace(string ns, bool createIfNotExists = false)
         {
             _model.Namespace = ns;
-            _model.ProvisioningMode = createOrUpdate
-                ? ServiceBusProvisioningMode.CreateOrUpdate
+            _model.ProvisioningMode = createIfNotExists
+                ? ServiceBusProvisioningMode.CreateIfNotExists
                 : ServiceBusProvisioningMode.UseExisting;
             return this;
         }

--- a/src/AzureCloudServiceBus/ServiceBusOptionsBuilder.cs
+++ b/src/AzureCloudServiceBus/ServiceBusOptionsBuilder.cs
@@ -30,10 +30,14 @@ namespace Squadron
         /// Namespace
         /// </summary>
         /// <param name="ns">The namespace.</param>
+        /// <param name="createOrUpdate">creates namespace if doesn't exist.</param>
         /// <returns></returns>
-        public ServiceBusOptionsBuilder Namespace(string ns)
+        public ServiceBusOptionsBuilder Namespace(string ns, bool createOrUpdate = false)
         {
             _model.Namespace = ns;
+            _model.ProvisioningMode = createOrUpdate
+                ? ServiceBusProvisioningMode.CreateOrUpdate
+                : ServiceBusProvisioningMode.UseExisting;
             return this;
         }
 


### PR DESCRIPTION
Added support for usage of existing Service Bus Namespaces

Creation of Service Bus Namespace is a timeconsuming task in Azure. This pull request addresses this issue with support for usage of existing Service Bus Namespace
- When a named Service Bus Namespace exists within resource group it can be used as is
- When a named Service Bus Namespace does not exist within resource group it will be created

Addresses #94
