### PR TITLE
Add host config memory setter

### DIFF
--- a/src/Core/ContainerResourceBuilder.cs
+++ b/src/Core/ContainerResourceBuilder.cs
@@ -208,6 +208,16 @@ namespace Squadron
         }
 
         /// <summary>
+        /// Sets the memory in Bytes
+        /// </summary>
+        /// <returns></returns>
+        public ContainerResourceBuilder Memory(long memory)
+        {
+            _options.Memory = memory;
+            return this;
+        }
+
+        /// <summary>
         /// Builds the settings
         /// </summary>
         /// <returns></returns>

--- a/src/Core/ContainerResourceSettings.cs
+++ b/src/Core/ContainerResourceSettings.cs
@@ -103,6 +103,11 @@ namespace Squadron
         public IList<CopyContext> FilesToCopy { get; internal set; } = new List<CopyContext>();
 
         /// <summary>
+        /// Memory of the container in Bytes
+        /// </summary>
+        public long Memory { get; internal set; }
+
+        /// <summary>
         /// Gets the docker configuration resolver.
         /// </summary>
         /// <value>

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -276,7 +276,8 @@ namespace Squadron
         {
             var hostConfig = new HostConfig
             {
-                PublishAllPorts = true
+                PublishAllPorts = true,
+                Memory = _settings.Memory,
             };
 
             if (_settings.ExternalPort > 0)


### PR DESCRIPTION
Add Memory ContainerResourceSetting in order to configure the memory per container. Especially necessary when LCOW is in use, since the standard of a Hyper-V isolated container is set at 1GB and for example the mcr.microsoft.com/mssql/server:2019-latest container would need at least of 2GB. 

Addresses #71 

Thanks for reviewing!
