### PR TITLE
Fix volume mapping

### DIFF
--- a/src/Core.Tests/Core.Tests.csproj
+++ b/src/Core.Tests/Core.Tests.csproj
@@ -30,6 +30,9 @@
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="test-volume\*.*">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Core.Tests/test-volume/index.html
+++ b/src/Core.Tests/test-volume/index.html
@@ -1,0 +1,10 @@
+﻿<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Docker Nginx</title>
+</head>
+<body>
+<h2>Hello Squadron unit test!</h2>
+</body>
+</html>

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -287,7 +287,8 @@ namespace Squadron
             {
                 PublishAllPorts = true,
                 Memory = _settings.Memory,
-                PortBindings = new Dictionary<string, IList<PortBinding>>()
+                PortBindings = new Dictionary<string, IList<PortBinding>>(),
+                Binds = _settings.Volumes
             };
 
             var allPorts = new List<ContainerPortMapping>
@@ -323,7 +324,6 @@ namespace Squadron
             {
                 Name = _settings.UniqueContainerName,
                 Image = _settings.ImageFullname,
-                Volumes = _settings.Volumes.ToDictionary(k => k, v => new EmptyStruct()),
                 AttachStdout = true,
                 AttachStderr = true,
                 AttachStdin = false,


### PR DESCRIPTION
- Fixes issue #89 by mapping volumes using the `HostConfig.Bind` property.
- Added unit test using nginx web server image to confirm volume mapping works as expected.

Adding volume mappings to `CreateContainerParameters.Volumes` doesn't seem to work as expected in Docker.Dotnet - the fix is to use the `Binds` property when creating a `HostConfig`. The issue is tracked here https://github.com/dotnet/Docker.DotNet/issues/226