### PR TITLE
Fix Squadron for Docker Desktop >= 4.7.0

### DIFF
--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -38,8 +38,8 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
   </ItemGroup>

--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -196,14 +196,14 @@ namespace Squadron
         public async Task InvokeCommandAsync(
                 ContainerExecCreateParameters parameters)
         {
-            ContainerExecCreateResponse response = await _client.Containers
+            ContainerExecCreateResponse response = await _client.Exec
                 .ExecCreateContainerAsync(
                     Instance.Id,
                     parameters);
 
             if (!string.IsNullOrEmpty(response.ID))
             {
-                using (MultiplexedStream stream = await _client.Containers
+                using (MultiplexedStream stream = await _client.Exec
                     .StartAndAttachContainerExecAsync(
                         response.ID, false))
                 {
@@ -413,7 +413,15 @@ namespace Squadron
                          {
                              IEnumerable<ImagesListResponse> listResponse =
                              await _client.Images.ListImagesAsync(
-                                 new ImagesListParameters { MatchName = _settings.ImageFullname });
+                                 new ImagesListParameters {
+                                     Filters = new Dictionary<string, IDictionary<string, bool>>
+                                     {
+                                         ["reference"] = new Dictionary<string, bool>
+                                         {
+                                             [_settings.ImageFullname] = true
+                                         }
+                                     }
+                                 });
 
                              return listResponse.Any();
                          }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Update Docker.DotNet to 3.125.5
- Adapt to ApiChanges of Docker.DotNet

Addresses #114 
