### PR TITLE
SqlServerResource: Added TrustServerCertificate=True;

### DIFF
--- a/src/SqlServer/SqlServerResource.cs
+++ b/src/SqlServer/SqlServerResource.cs
@@ -172,7 +172,8 @@ namespace Squadron
                 .Append("Integrated Security=False;")
                 .Append($"User ID={Settings.Username};")
                 .Append($"Password={Settings.Password};")
-                .Append($"MultipleActiveResultSets=True;")
+                .Append("MultipleActiveResultSets=True;")
+                .Append("TrustServerCertificate=True;")
                 .ToString();
 
         internal async Task DeployAndExecute(string sqlScript)


### PR DESCRIPTION
After updating `Microsoft.Data.SqlClient` to version 4.x, the following error occured:
> A connection was successfully established with the server, but then an error occurred during the login process. (provider: SSL Provider, error: 0 - The certificate chain was issued by an authority that is not trusted.)

This has to do with a change in the default values used to set up a connection - every connection is now encrypted by default:
https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/

This awesome blog article describes the issue in detail:
https://weblog.west-wind.com/posts/2021/Dec/07/Connection-Failures-with-MicrosoftDataSqlClient-4-and-later

Since Squadron is mostly used in test scenarios, there should be no issue at all in trusting the connection. This is why I appended `TrustServerCertificate=True;` to the connection string by default.