### PR TITLE
Migrated to Microsoft.Data.SqlClient

### DIFF
--- a/src/SqlServer.Tests/SqlServer2019Tests.cs
+++ b/src/SqlServer.Tests/SqlServer2019Tests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Threading.Tasks;
 using Squadron.Resources;
 using Xunit;

--- a/src/SqlServer.Tests/SqlServerResourceTests.cs
+++ b/src/SqlServer.Tests/SqlServerResourceTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data.SqlClient;
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/SqlServer/SqlServer.csproj
+++ b/src/SqlServer/SqlServer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(CCResourceProjectProps)" Condition="Exists('$(CCResourceProjectProps)')" />
 
   <PropertyGroup>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="150.4505.1-preview" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SqlServer/SqlServerResource.cs
+++ b/src/SqlServer/SqlServerResource.cs
@@ -172,7 +172,8 @@ namespace Squadron
                 .Append("Integrated Security=False;")
                 .Append($"User ID={Settings.Username};")
                 .Append($"Password={Settings.Password};")
-                .Append($"MultipleActiveResultSets=True;")
+                .Append("MultipleActiveResultSets=True;")
+                .Append("TrustServerCertificate=True;")
                 .ToString();
 
         internal async Task DeployAndExecute(string sqlScript)

--- a/src/SqlServer/SqlServerStatus.cs
+++ b/src/SqlServer/SqlServerStatus.cs
@@ -1,6 +1,6 @@
-using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 
 namespace Squadron
 {
@@ -29,14 +29,13 @@ namespace Squadron
             {
                 await connection.OpenAsync(cancellationToken);
 
-                using (System.Data.SqlClient.SqlCommand command = connection.CreateCommand())
+                Microsoft.Data.SqlClient.SqlCommand command = connection.CreateCommand();
+                command.CommandText = "SELECT Count(name) FROM sys.databases";
+
+                return new Status
                 {
-                    command.CommandText = "SELECT Count(name) FROM sys.databases";
-                    return new Status
-                    {
-                        IsReady = (int)await command.ExecuteScalarAsync(cancellationToken) >= 4
-                    };
-                }
+                    IsReady = (int)await command.ExecuteScalarAsync(cancellationToken) >= 4
+                };
             }
         }
     }

--- a/src/SqlServer/SqlServerStatus.cs
+++ b/src/SqlServer/SqlServerStatus.cs
@@ -29,13 +29,14 @@ namespace Squadron
             {
                 await connection.OpenAsync(cancellationToken);
 
-                Microsoft.Data.SqlClient.SqlCommand command = connection.CreateCommand();
-                command.CommandText = "SELECT Count(name) FROM sys.databases";
-
-                return new Status
+                using (Microsoft.Data.SqlClient.SqlCommand command = connection.CreateCommand())
                 {
-                    IsReady = (int)await command.ExecuteScalarAsync(cancellationToken) >= 4
-                };
+                    command.CommandText = "SELECT Count(name) FROM sys.databases";
+                    return new Status
+                    {
+                        IsReady = (int)await command.ExecuteScalarAsync(cancellationToken) >= 4
+                    };
+                }
             }
         }
     }


### PR DESCRIPTION
Since newer versions of Entity Framework use Microsoft.Data.SqlClient, I thought it may be a good idea to migrate Squadron away from System.Data.SqlClient as well.