### PR TITLE
Support DOCKER_HOST environment variable

### DIFF
--- a/src/Core/DockerContainerManager.cs
+++ b/src/Core/DockerContainerManager.cs
@@ -84,6 +84,13 @@ namespace Squadron
 
         private static Uri LocalDockerUri()
         {
+            var envHost = Environment.GetEnvironmentVariable("DOCKER_HOST");
+
+            if (!string.IsNullOrEmpty(envHost))
+            {
+                return new Uri(envHost);
+            }
+
 #if NET461
             return new Uri("npipe://./pipe/docker_engine");
 #else


### PR DESCRIPTION
By default Squadron connects to a predefined hardcoded default daemons. With support of this [Docker variable](https://docs.docker.com/engine/reference/commandline/cli/) Squadron will be able to connect to different daemons like e.g. [colima](https://github.com/abiosoft/colima). 

The motivation for this change was the ability to emulate certain images dedicated for x86 architecture on Apple M1 devices. E.g. Sql Server image.