### PR TITLE
Add implementation for NATS resource

### DIFF
--- a/src/Nats.Tests/Nats.Tests.csproj
+++ b/src/Nats.Tests/Nats.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+
+        <LangVersion>default</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AlterNats.Hosting" Version="1.0.5" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="System.Text.Json" Version="6.0.6" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Nats\Nats.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Nats.Tests/NatsResourceTests.cs
+++ b/src/Nats.Tests/NatsResourceTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AlterNats;
+using Squadron;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nats.Tests;
+
+public class NatsResourceTests : IClassFixture<NatsResource>
+{
+    private readonly NatsResource _nats;
+    private readonly ITestOutputHelper _helper;
+
+    public NatsResourceTests(NatsResource nats, ITestOutputHelper helper)
+    {
+        _nats = nats;
+        _helper = helper;
+    }
+    
+    [Fact]
+    public async Task Client_Will_Connect()
+    {
+        var options = NatsOptions.Default with { Url = _nats.NatsConnectionString };
+        var client = new NatsConnection(options);
+
+        await client.ConnectAsync();
+        _helper.WriteLine("NATS Client is connected to: " + _nats.NatsConnectionString);
+
+        await client.DisposeAsync();
+        _helper.WriteLine("NATS Client disconnected.");
+
+        Assert.True(true);
+    }
+
+    [Fact]
+    public async Task Publish_Subscribe_Topic()
+    {
+        var options = NatsOptions.Default with { Url = _nats.NatsConnectionString };
+        var client = new NatsConnection(options);
+
+        await client.ConnectAsync();
+        _helper.WriteLine("NATS Client is connected to: " + _nats.NatsConnectionString);
+
+        var semaphore = new SemaphoreSlim(0);
+        await client.SubscribeAsync("test", () =>
+        {
+             _helper.WriteLine("Received message on test topic");
+             semaphore.Release();
+        });
+
+        var timeout = Task.Delay(TimeSpan.FromSeconds(2));
+
+        await client.PublishAsync("test", "Hello World!");
+        _helper.WriteLine("Published message on test topic");
+
+        Task winner = await Task.WhenAny(new[]
+        {
+            semaphore.WaitAsync(),
+            timeout
+        });
+
+        if (winner == timeout)
+        {
+            Assert.True(false, "Timeout waiting for message");
+        }
+
+        await client.DisposeAsync();
+        semaphore.Dispose();
+
+        _helper.WriteLine("NATS Client disconnected.");
+
+        Assert.True(true);
+
+    }
+}

--- a/src/Nats.Tests/NatsResourceTests.cs
+++ b/src/Nats.Tests/NatsResourceTests.cs
@@ -18,7 +18,7 @@ public class NatsResourceTests : IClassFixture<NatsResource>
         _nats = nats;
         _helper = helper;
     }
-    
+
     [Fact]
     public async Task Client_Will_Connect()
     {
@@ -72,6 +72,5 @@ public class NatsResourceTests : IClassFixture<NatsResource>
         _helper.WriteLine("NATS Client disconnected.");
 
         Assert.True(true);
-
     }
 }

--- a/src/Nats/Nats.csproj
+++ b/src/Nats/Nats.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(CCResourceProjectProps)" Condition="Exists('$(CCResourceProjectProps)')" />
+
+  <PropertyGroup>
+    <AssemblyName>Squadron.Nats</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
+    <PackageReference Remove="xunit.core" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Core\Core.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/src/Nats/Nats.csproj
+++ b/src/Nats/Nats.csproj
@@ -14,6 +14,4 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
-
-
 </Project>

--- a/src/Nats/NatsDefaultOptions.cs
+++ b/src/Nats/NatsDefaultOptions.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Squadron
+{
+    /// <summary>
+    /// Default NATS resource options
+    /// </summary>
+    public class NatsDefaultOptions
+        : ContainerResourceOptions,
+        IComposableResourceOption
+    {
+        public Type ResourceType => typeof(NatsResource);
+
+        /// <summary>
+        /// Configure resource options
+        /// </summary>
+        /// <param name="builder"></param>
+        public override void Configure(ContainerResourceBuilder builder)
+        {
+            // 4222 is for clients.
+            // 8222 is an HTTP management port for information reporting.
+            // 6222 is a routing port for clustering (not used).
+
+            builder
+                .Name("nats")
+                .Image("nats:latest")
+                .AddVariable("nats-monitoring", VariableType.DynamicPort)
+                .InternalPort(4222) // automatically dynamic because no use of ExternalPort
+                .AddPortMapping(8222, "nats-monitoring");
+        }
+    }
+}

--- a/src/Nats/NatsDefaultOptions.cs
+++ b/src/Nats/NatsDefaultOptions.cs
@@ -6,8 +6,8 @@ namespace Squadron
     /// Default NATS resource options
     /// </summary>
     public class NatsDefaultOptions
-        : ContainerResourceOptions,
-        IComposableResourceOption
+        : ContainerResourceOptions
+        , IComposableResourceOption
     {
         public Type ResourceType => typeof(NatsResource);
 

--- a/src/Nats/NatsResource.cs
+++ b/src/Nats/NatsResource.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Squadron
+{
+    /// <inheritdoc/>
+    public class NatsResource : NatsResource<NatsDefaultOptions> { }
+
+    /// <summary>
+    /// Represents a NATS resource that can be used by unit tests.
+    /// </summary>
+    public class NatsResource<TOptions>
+        : ContainerResource<TOptions>,
+          IAsyncLifetime,
+          IComposableResource
+        where TOptions : ContainerResourceOptions, new()
+    {
+        /// <summary>
+        /// NATS Client ConnectionString, in the format of "nats://localhost:port"
+        /// </summary>
+        public string NatsConnectionString { get; private set; }
+
+        /// <inheritdoc cref="IAsyncLifetime"/>
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+            var baseAddressClient = $"{Manager.Instance.Address}:{Manager.Instance.HostPort}";
+            var baseAddressMonitoring = $"{Manager.Instance.Address}:{Manager.Instance.AdditionalPorts[0].ExternalPort}";
+            NatsConnectionString = $"nats://{baseAddressClient}";
+
+            await Initializer.WaitAsync(new NatsStatus(baseAddressMonitoring));
+        }
+    }
+}

--- a/src/Nats/NatsResource.cs
+++ b/src/Nats/NatsResource.cs
@@ -25,8 +25,10 @@ namespace Squadron
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
-            var baseAddressClient = $"{Manager.Instance.Address}:{Manager.Instance.HostPort}";
-            var baseAddressMonitoring = $"{Manager.Instance.Address}:{Manager.Instance.AdditionalPorts[0].ExternalPort}";
+            var baseAddressClient =
+                $"{Manager.Instance.Address}:{Manager.Instance.HostPort}";
+            var baseAddressMonitoring =
+                $"{Manager.Instance.Address}:{Manager.Instance.AdditionalPorts[0].ExternalPort}";
             NatsConnectionString = $"nats://{baseAddressClient}";
 
             await Initializer.WaitAsync(new NatsStatus(baseAddressMonitoring));

--- a/src/Nats/NatsStatus.cs
+++ b/src/Nats/NatsStatus.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Squadron
+{
+    /// <summary>
+    /// Status checker for Redis
+    /// </summary>
+    /// <seealso cref="IResourceStatusProvider" />
+    public class NatsStatus : IResourceStatusProvider, IDisposable
+    {
+        private readonly HttpClient _httpClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NatsStatus"/> class.
+        /// </summary>
+        /// <param name="host">Hostname</param>
+        public NatsStatus(string host)
+        {
+            Debug.Assert(
+                Uri.TryCreate($"http://{host}/", UriKind.Absolute, out Uri uri),
+                $"Bad host string '{host}'");
+
+            _httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(5),
+                BaseAddress = uri
+            };
+        }
+
+        /// <inheritdoc/>
+        public async Task<Status> IsReadyAsync(CancellationToken cancellationToken)
+        {
+            try {
+                HealthzResponse response = await _httpClient.GetFromJsonAsync<HealthzResponse>(
+                    new Uri("/healthz", UriKind.Relative), cancellationToken);
+
+                Debug.Assert(response?.Status == "ok", "status == 'ok'");
+
+                return new Status
+                {
+                    IsReady = true,
+                    Message = "NATS is ready!"
+                };
+
+            }
+            catch (Exception ex)
+            {
+                return new Status
+                {
+                    IsReady = false,
+                    Message = ex.Message
+                };
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+
+        // ReSharper disable once IdentifierTypo
+        internal class HealthzResponse
+        {
+            public string Status { get; set; }
+        }
+    }
+}

--- a/src/Nats/NatsStatus.cs
+++ b/src/Nats/NatsStatus.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 namespace Squadron
 {
     /// <summary>
-    /// Status checker for Redis
+    /// Status checker for Nats
     /// </summary>
     /// <seealso cref="IResourceStatusProvider" />
     public class NatsStatus : IResourceStatusProvider, IDisposable
@@ -65,7 +65,7 @@ namespace Squadron
         }
 
         // ReSharper disable once IdentifierTypo
-        internal class HealthzResponse
+        private class HealthzResponse
         {
             public string Status { get; set; }
         }

--- a/src/Squadron.sln
+++ b/src/Squadron.sln
@@ -82,6 +82,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFtpServer", "SFtpServer\SF
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFtpServer.Tests", "SFtpServer.Tests\SFtpServer.Tests.csproj", "{73305BD0-122E-42F6-A3FE-582A9FA12168}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nats", "Nats\Nats.csproj", "{1B77498F-431E-4C13-9434-D64CA09C731D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nats.Tests", "Nats.Tests\Nats.Tests.csproj", "{2164CEEC-9F13-44D3-95B9-ED81AAC74189}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -560,6 +564,30 @@ Global
 		{73305BD0-122E-42F6-A3FE-582A9FA12168}.Release|x64.Build.0 = Release|Any CPU
 		{73305BD0-122E-42F6-A3FE-582A9FA12168}.Release|x86.ActiveCfg = Release|Any CPU
 		{73305BD0-122E-42F6-A3FE-582A9FA12168}.Release|x86.Build.0 = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|x64.Build.0 = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B77498F-431E-4C13-9434-D64CA09C731D}.Release|x86.Build.0 = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|x64.Build.0 = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Debug|x86.Build.0 = Debug|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|x64.ActiveCfg = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|x64.Build.0 = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|x86.ActiveCfg = Release|Any CPU
+		{2164CEEC-9F13-44D3-95B9-ED81AAC74189}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Single node support for NatsResource

- tests for connection and publish/subscribe cycle
- exposes client connectionstring
- uses monitoring health endpoint for readiness check
- dynamic port mapping for external ports

Future iterations could add support for clustering (not sure if squadron allows this?)

