### PR TITLE
Return stdout from commands

### DIFF
--- a/src/Core/ContainerResourceSettings.cs
+++ b/src/Core/ContainerResourceSettings.cs
@@ -55,7 +55,7 @@ namespace Squadron
         /// <value>
         /// The name of the registry.
         /// </value>
-        public string RegistryName { get; internal set; }
+        public string? RegistryName { get; internal set; }
 
         public ContainerAddressMode AddressMode { get; internal set; }
 

--- a/src/Core/IDockerContainerManager.cs
+++ b/src/Core/IDockerContainerManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Docker.DotNet;
 using Docker.DotNet.Models;
 
 namespace Squadron
@@ -16,6 +17,11 @@ namespace Squadron
         /// The instance.
         /// </value>
         ContainerInstance Instance { get; }
+        
+        /// <summary>
+        /// The client to interact with docker
+        /// </summary>
+        DockerClient Client { get; }
 
         /// <summary>
         /// Consumes container logs
@@ -41,7 +47,7 @@ namespace Squadron
         /// </summary>
         /// <param name="parameters">Command parameter</param>
         /// <exception cref="ContainerException"></exception>
-        Task InvokeCommandAsync(ContainerExecCreateParameters parameters);
+        Task<string?> InvokeCommandAsync(ContainerExecCreateParameters parameters);
 
         /// <summary>
         /// Removes the container.


### PR DESCRIPTION
- Exposed DockerClient in IDockerContainerManager interface and moved its initialization to a public property Client in DockerContainerManager, enabling better access to the Docker client outside of the class.
- Updated InvokeCommandAsync to return stdout as a string, improving usability by returning command output directly.