### PR TITLE
bumps MongoDb.Driver to 2.28.0

### DIFF
--- a/src/Mongo/Mongo.csproj
+++ b/src/Mongo/Mongo.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.23.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
MongoDb.Driver introduces [Strong-Named Assemblies](https://jira.mongodb.org/browse/CSHARP-1276) in [2.28.0](https://github.com/mongodb/mongo-csharp-driver/releases/tag/v2.28.0). Causing issues in projects using MongoDb >2.28.0

This PR bumps MongoDb to that version to resolve that issue.

Closes #139 