### PR TITLE
Fix Docker auth

### DIFF
--- a/src/Core/ContainerResourceOptions.cs
+++ b/src/Core/ContainerResourceOptions.cs
@@ -53,7 +53,6 @@ namespace Squadron
 
                     if (containerConfig.Registries.Any(p =>
                             p.Address.Equals(address.ToString(), StringComparison.InvariantCultureIgnoreCase)) ||
-                        string.IsNullOrEmpty(auth.Value.Email) ||
                         string.IsNullOrEmpty(auth.Value.Auth))
                     {
                         continue;


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Fix Docker auth.

---

When using `docker login --username example` along with a PAT, only an `auth` property is written to the `config.json` file, and not an `email` property. The `email` property is checked for `null` despite the fact that this property is not used, so I've removed this check.