### PR TITLE
Downgrade MongoDB.Driver package version to 3.0.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -56,7 +56,7 @@
         <PackageVersion Include="Polly" Version="8.5.2" />
         <PackageVersion Include="SharpZipLib" Version="1.4.2" />
 
-        <PackageVersion Include="MongoDB.Driver" Version="3.4.0" />
+        <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
         <PackageVersion Include="MySqlConnector" Version="2.4.0" />
         <PackageVersion Include="Npgsql" Version="8.0.7" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- Downgrade MongoDB.Driver package version to 3.0.0.

---

Allow consumers to use previous versions of 3.x without package downgrade warnings.