### PR TITLE
feat: update Testcontainers packages to version 4.10.0 and SSH.NET to…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,15 +50,15 @@
 
         <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
 
-        <PackageVersion Include="Testcontainers" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.MongoDb" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.Redis" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.MySql" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.MsSql" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.3.0" />
-        <PackageVersion Include="Testcontainers.MariaDb" Version="4.3.0" />
+        <PackageVersion Include="Testcontainers" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.MongoDb" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.Redis" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.MySql" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.MsSql" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers.MariaDb" Version="4.10.0" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 
         <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
@@ -89,9 +89,8 @@
         <PackageVersion Include="Typesense" Version="7.33.0" />
 
         <PackageVersion Include="FluentFTP" Version="35.0.4" />
-        <PackageVersion Include="SSH.NET" Version="2024.2.0" />
-
-
+        <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+        
         <PackageVersion Include="ServiceStack.Text" Version="8.8.0" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     </ItemGroup>

--- a/src/Core/TestcontainersDockerManager.cs
+++ b/src/Core/TestcontainersDockerManager.cs
@@ -251,7 +251,7 @@ public class TestcontainersDockerManager : IDockerContainerManager
             var fileBytes = await File.ReadAllBytesAsync(context.Source);
             const UnixFileModes fileMode = UnixFileModes.UserRead | UnixFileModes.UserWrite | 
                                            UnixFileModes.GroupRead | UnixFileModes.OtherRead;
-            await _container.CopyAsync(fileBytes, context.Destination, fileMode);
+            await _container.CopyAsync(fileBytes, context.Destination, (uint)fileMode);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Updated testcontainers to 4.10.0 - supports Docker Engine v29