### PR TITLE
feat: update MongoDB.Driver package version to 3.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
         <PackageVersion Include="Testcontainers.MariaDb" Version="4.10.0" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 
-        <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
+        <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
         <PackageVersion Include="MySqlConnector" Version="2.4.0" />
         <PackageVersion Include="Npgsql" Version="8.0.7" />
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.2" />


### PR DESCRIPTION
This pull request updates the `MongoDB.Driver` package to a newer version in the `Directory.Packages.props` file. This change ensures compatibility with newer MongoDB features and may include important bug fixes and performance improvements.

Dependency updates:

* Upgraded the `MongoDB.Driver` package from version 3.0.0 to 3.9.0 in `Directory.Packages.props`.