### PR TITLE
fix: update Testcontainers and SSH.NET

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,15 +47,15 @@
 
         <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
 
-        <PackageVersion Include="Testcontainers" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.MongoDb" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.Redis" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.MySql" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.MsSql" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.10.0" />
-        <PackageVersion Include="Testcontainers.MariaDb" Version="4.10.0" />
+        <PackageVersion Include="Testcontainers" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.MongoDb" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.Redis" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.RabbitMq" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.MySql" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.MsSql" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.14.0" />
+        <PackageVersion Include="Testcontainers.MariaDb" Version="4.14.0" />
         <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 
         <PackageVersion Include="MongoDB.Driver" Version="3.9.0" />
@@ -86,7 +86,7 @@
         <PackageVersion Include="Typesense" Version="7.33.0" />
 
         <PackageVersion Include="FluentFTP" Version="35.0.4" />
-        <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+        <PackageVersion Include="SSH.NET" Version="2026.0.0" />
         
         <PackageVersion Include="ServiceStack.Text" Version="8.8.0" />
         <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />


### PR DESCRIPTION
Updates the Testcontainers package family to 4.14.0 and SSH.NET to 2026.0.0. Testcontainers 4.14.0 resolves the fixed SSH.NET release for downstream Squadron consumers.
